### PR TITLE
main merge

### DIFF
--- a/app/src/main/java/com/example/mycolor/Fragment/MyPageFragment.kt
+++ b/app/src/main/java/com/example/mycolor/Fragment/MyPageFragment.kt
@@ -135,7 +135,7 @@ class MyPageFragment : Fragment() {
 
         }
 
-        fetchPersonalColorInfo()
+        //fetchPersonalColorInfo()
 
         baseProductTextViews = listOf(
             view.findViewById(R.id.baseproductTextView_11),
@@ -203,21 +203,36 @@ class MyPageFragment : Fragment() {
     }
 
 
+//    private fun getImageViewsByCategory(category: String): List<ImageView> {
+//        //Toast.makeText(context, "$category 카테고리의 이미지 뷰 로드 중...", Toast.LENGTH_SHORT).show()
+//        return listOf(
+//            requireView().findViewById(resources.getIdentifier("${category}imageView_1", "id", context?.packageName)),
+//            requireView().findViewById(resources.getIdentifier("${category}imageView_2", "id", context?.packageName)),
+//            requireView().findViewById(resources.getIdentifier("${category}imageView_3", "id", context?.packageName))
+//        )
+//    }
+
     private fun getImageViewsByCategory(category: String): List<ImageView> {
-        //Toast.makeText(context, "$category 카테고리의 이미지 뷰 로드 중...", Toast.LENGTH_SHORT).show()
+        // 현재 뷰가 null인지 확인하고, null이 아니면 진행
+        val currentView = view ?: return emptyList()  // view가 null이면 빈 리스트를 반환
+
         return listOf(
-            requireView().findViewById(resources.getIdentifier("${category}imageView_1", "id", context?.packageName)),
-            requireView().findViewById(resources.getIdentifier("${category}imageView_2", "id", context?.packageName)),
-            requireView().findViewById(resources.getIdentifier("${category}imageView_3", "id", context?.packageName))
+            currentView.findViewById(resources.getIdentifier("${category}imageView_1", "id", context?.packageName)),
+            currentView.findViewById(resources.getIdentifier("${category}imageView_2", "id", context?.packageName)),
+            currentView.findViewById(resources.getIdentifier("${category}imageView_3", "id", context?.packageName))
         )
     }
+
 
     private fun loadImages(storageRef: StorageReference, categoryPrefix: String, category: String, imageViews: List<ImageView>, urls: List<String>) {
         imageViews.forEachIndexed { index, imageView ->
             val imagePath = "products/$categoryPrefix/${categoryPrefix}_${category}_${index + 1}.jpg"
             val imageRef = storageRef.child(imagePath)
             imageRef.downloadUrl.addOnSuccessListener { uri ->
-                Glide.with(this).load(uri).into(imageView)
+                if(isAdded){
+                    Glide.with(this).load(uri).into(imageView)
+                }
+
                 imageView.setOnClickListener {
                     if (urls[index] != "none") {
                         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(urls[index]))


### PR DESCRIPTION
GCP Server에 RGB 이미지 데이터로 학습된 모델 적용

FireStore연동
resultFragment에서 과거 진단 결과 보는 로직 추가 필요

- mypage + login + sih_add_fireStore + Dy_add_fireStore

- optimization : remove Actionbar, picture using camera directly rotation, fixed Light mode, rename app, change mipmap, layout modified, remove deprecated methods, add dialog, modify navigation, delete HomeFragment activity, layout, nav graph

- 리사이클러 뷰 수정 및 클릭리스너 추가, ResultFragment.kt 사진 추가

- resultFragment.kt, DetailResultActivity.kt 로직 완성

- 실시간 진단 결과에 제품 출력 완료

- 회원가입 시 이름 입력
- 마이페이지 이름 출력 및 로그아웃 구현

- 마이페이지에서 이미지 클릭 시 제품 웹페이지로 이동(WebActivity.kt, xml 추가)

- MyPageFragment.kt 프레그먼트 전환 시 IllegalStateException문제 해결