### PR TITLE
AWS -> GCP으로 Server 이동

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -4,6 +4,17 @@
     <value>
       <entry key="app">
         <State>
+          <runningDeviceTargetSelectedWithDropDown>
+            <Target>
+              <type value="RUNNING_DEVICE_TARGET" />
+              <deviceKey>
+                <Key>
+                  <type value="VIRTUAL_DEVICE_PATH" />
+                  <value value="C:\Users\y3gre\.android\avd\Pixel_7_API_33.avd" />
+                </Key>
+              </deviceKey>
+            </Target>
+          </runningDeviceTargetSelectedWithDropDown>
           <targetSelectedWithDropDown>
             <Target>
               <type value="QUICK_BOOT_TARGET" />
@@ -15,7 +26,7 @@
               </deviceKey>
             </Target>
           </targetSelectedWithDropDown>
-          <timeTargetWasSelectedWithDropDown value="2024-05-17T08:35:16.513421Z" />
+          <timeTargetWasSelectedWithDropDown value="2024-05-17T09:28:58.332281200Z" />
         </State>
       </entry>
     </value>

--- a/app/src/main/java/com/example/mycolor/Fragment/MyPageFragment.kt
+++ b/app/src/main/java/com/example/mycolor/Fragment/MyPageFragment.kt
@@ -100,7 +100,8 @@ class MyPageFragment : Fragment() {
                                 val result = resultDocument.getString("result") ?: ""
                                 val date = resultDocument.getDate("date")  // Firestore의 Timestamp를 Date 객체로 변환
 
-                                nameTextView2.text = result
+                                val replacedResult = result.replace("_", " ")
+                                nameTextView2.text = replacedResult
 
                                 Log.d("Firestore", "Personal Color: $result")
                             }

--- a/app/src/main/java/com/example/mycolor/Fragment/ResultFragment.kt
+++ b/app/src/main/java/com/example/mycolor/Fragment/ResultFragment.kt
@@ -92,7 +92,8 @@ class ResultFragment : Fragment() {
                                     actualDate
                                 )
                             val result = document.getString("result") ?: "No result available"
-                            DiagnosticResult(formattedDate, result, actualDate)
+                            val replacedResult = result.replace("_", " ")
+                            DiagnosticResult(formattedDate, replacedResult, actualDate)
                         } else {
                             null // Skip this entry if the date is null
                         }


### PR DESCRIPTION
GCP Server에 RGB 이미지 데이터로 학습된 모델 적용

FireStore연동
resultFragment에서 과거 진단 결과 보는 로직 추가 필요

- mypage + login + sih_add_fireStore + Dy_add_fireStore

- optimization : remove Actionbar, picture using camera directly rotation, fixed Light mode, rename app, change mipmap, layout modified, remove deprecated methods, add dialog, modify navigation, delete HomeFragment activity, layout, nav graph

- 리사이클러 뷰 수정 및 클릭리스너 추가, ResultFragment.kt 사진 추가

- resultFragment.kt, DetailResultActivity.kt 로직 완성

- 실시간 진단 결과에 제품 출력 완료

- 회원가입 시 이름 입력
- 마이페이지 이름 출력 및 로그아웃 구현

- 마이페이지에서 이미지 클릭 시 제품 웹페이지로 이동(WebActivity.kt, xml 추가)

- MyPageFragment.kt 프레그먼트 전환 시 IllegalStateException문제 해결

- Server 및 데이터 크롤링, 전처리, 모델 학습 python 코드 추가